### PR TITLE
Support maplibre-gl-js v5.7.2 or higher

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     maplibre-gl:
-      specifier: 5.6.2
-      version: 5.6.2
+      specifier: 5.10.0
+      version: 5.10.0
     npm-run-all2:
       specifier: ^8.0.4
       version: 8.0.4
@@ -34,7 +34,7 @@ importers:
         version: 3.4.4
       maplibre-gl:
         specifier: 'catalog:'
-        version: 5.6.2
+        version: 5.10.0
       npm-run-all2:
         specifier: 'catalog:'
         version: 8.0.4
@@ -58,7 +58,7 @@ importers:
         version: link:..
       maplibre-gl:
         specifier: 'catalog:'
-        version: 5.6.2
+        version: 5.10.0
       vue:
         specifier: ^3.5.28
         version: 3.5.28(typescript@5.8.3)
@@ -309,12 +309,15 @@ packages:
     resolution: {integrity: sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==}
     engines: {node: '>=6.0.0'}
 
-  '@maplibre/maplibre-gl-style-spec@23.3.0':
-    resolution: {integrity: sha512-IGJtuBbaGzOUgODdBRg66p8stnwj9iDXkgbYKoYcNiiQmaez5WVRfXm4b03MCDwmZyX93csbfHFWEJJYHnn5oA==}
+  '@maplibre/geojson-vt@5.0.4':
+    resolution: {integrity: sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==}
+
+  '@maplibre/maplibre-gl-style-spec@24.4.1':
+    resolution: {integrity: sha512-UKhA4qv1h30XT768ccSv5NjNCX+dgfoq2qlLVmKejspPcSQTYD4SrVucgqegmYcKcmwf06wcNAa/kRd0NHWbUg==}
     hasBin: true
 
-  '@maplibre/vt-pbf@4.0.3':
-    resolution: {integrity: sha512-YsW99BwnT+ukJRkseBcLuZHfITB4puJoxnqPVjo72rhW/TaawVYsgQHcqWLzTxqknttYoDpgyERzWSa/XrETdA==}
+  '@maplibre/vt-pbf@4.2.1':
+    resolution: {integrity: sha512-IxZBGq/+9cqf2qdWlFuQ+ZfoMhWpxDUGQZ/poPHOJBvwMUT1GuxLo6HgYTou+xxtsOsjfbcjI8PZaPCtmt97rA==}
 
   '@microsoft/api-documenter@7.29.2':
     resolution: {integrity: sha512-6yO8mxwUyKwk8p3X0uKC3nMLpB7AEmN+KcCBlmuWZxn57jERWzsumBO7KQsW7q+AxzRJp18vwFNekUY4Lwqbyw==}
@@ -780,8 +783,8 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  maplibre-gl@5.6.2:
-    resolution: {integrity: sha512-SEqYThhUCFf6Lm0TckpgpKnto5u4JsdPYdFJb6g12VtuaFsm3nYdBO+fOmnUYddc8dXihgoGnuXvPPooUcRv5w==}
+  maplibre-gl@5.10.0:
+    resolution: {integrity: sha512-eLhlX8Fnpaoo7+uGqggZmXmZld6WrbzOJUPB7G8JB8XpminlTnrQTtXilMHduR8fsNVxrzD8yRRqEoajONc8LQ==}
     engines: {node: '>=16.14.0', npm: '>=8.1.0'}
 
   memorystream@0.3.1:
@@ -1180,7 +1183,9 @@ snapshots:
 
   '@mapbox/whoots-js@3.1.0': {}
 
-  '@maplibre/maplibre-gl-style-spec@23.3.0':
+  '@maplibre/geojson-vt@5.0.4': {}
+
+  '@maplibre/maplibre-gl-style-spec@24.4.1':
     dependencies:
       '@mapbox/jsonlint-lines-primitives': 2.0.2
       '@mapbox/unitbezier': 0.0.1
@@ -1190,13 +1195,13 @@ snapshots:
       rw: 1.3.3
       tinyqueue: 3.0.0
 
-  '@maplibre/vt-pbf@4.0.3':
+  '@maplibre/vt-pbf@4.2.1':
     dependencies:
       '@mapbox/point-geometry': 1.1.0
       '@mapbox/vector-tile': 2.0.4
-      '@types/geojson-vt': 3.2.5
+      '@maplibre/geojson-vt': 5.0.4
+      '@types/geojson': 7946.0.16
       '@types/supercluster': 7.1.3
-      geojson-vt: 4.0.2
       pbf: 4.0.1
       supercluster: 8.0.1
 
@@ -1669,7 +1674,7 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  maplibre-gl@5.6.2:
+  maplibre-gl@5.10.0:
     dependencies:
       '@mapbox/geojson-rewind': 0.5.2
       '@mapbox/jsonlint-lines-primitives': 2.0.2
@@ -1678,8 +1683,8 @@ snapshots:
       '@mapbox/unitbezier': 0.0.1
       '@mapbox/vector-tile': 2.0.4
       '@mapbox/whoots-js': 3.1.0
-      '@maplibre/maplibre-gl-style-spec': 23.3.0
-      '@maplibre/vt-pbf': 4.0.3
+      '@maplibre/maplibre-gl-style-spec': 24.4.1
+      '@maplibre/vt-pbf': 4.2.1
       '@types/geojson': 7946.0.16
       '@types/geojson-vt': 3.2.5
       '@types/supercluster': 7.1.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,6 @@ packages:
   - example
 
 catalog:
-  maplibre-gl: 5.6.2
+  maplibre-gl: 5.10.0
   npm-run-all2: ^8.0.4
   typescript: 5.8.3

--- a/src/private/maplibre-types.ts
+++ b/src/private/maplibre-types.ts
@@ -36,6 +36,9 @@ export type Bucket = Tile['buckets']['string'];
 //
 // https://github.com/maplibre/maplibre-gl-js/blob/7887f2c899dcc7f7bfa8a05f5a98c92bf1a5bf5a/src/data/bucket/symbol_bucket.ts#L277-L955
 export type SymbolBucket = Bucket & {
+  // `globalState` was introduced in v5.6.0 but was removed in v5.7.2
+  // https://github.com/maplibre/maplibre-gl-js/blob/b3e282bbb0b8f93b503895281ec313a4e2a1c6be/src/data/bucket/symbol_bucket.ts#L315
+  globalState?: Record<string, any>;
   bucketInstanceId: number;
   symbolInstances: SymbolInstanceArray;
   collisionArrays: CollisionArrays[];


### PR DESCRIPTION
### Proposed changes

`maplibre-gl-js` v5.7.2 changed the signature of the `lookupSymbolFeatures` method of `FeatureIndex`, and the change stopped this library working.

Works around the problem by determining the version is 5.7.2 or higher.

`maplibre-gl-js` v5.11.0 or higher has another problem, but I will address it in another issue.

### Related issue(s)

- closes #1