### PR TITLE
Support maplibre-gl v5.11.0 or higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,20 +9,20 @@ A utility library for [Maplibre GL JS (`maplibre-gl`)](https://github.com/maplib
 ### Prerequisites
 
 This library is intended to work with `maplibre-gl` version 5.x.
-(This library has been developed with v5.6.2.)
+(This library has been tested with v5.18.0.)
 
 ### How to install
 
 Please add this repository to your dependencies.
 
 ```sh
-npm install https://github.com/codemonger-io/maplibre-collision-boxes#v0.1.0
+npm install https://github.com/codemonger-io/maplibre-collision-boxes#v0.1.1
 ```
 
 #### Installing from GitHub Packages
 
 Whenever commits are pushed to the `main` branch, a _developer package_ is published to the npm registry managed by GitHub Packages.
-A _developer package_ bears the next release version but followed by a dash (`-`) plus the short commit hash; e.g., `0.1.0-abc1234` where `abc1234` is the short commit hash of the commit used to build the package (_snapshot_).
+A _developer package_ bears the next release version but followed by a dash (`-`) plus the short commit hash; e.g., `0.1.1-abc1234` where `abc1234` is the short commit hash of the commit used to build the package (_snapshot_).
 You can find _developer packages_ [here](https://github.com/codemonger-io/maplibre-collision-boxes/pkgs/npm/maplibre-collision-boxes).
 
 ##### Configuring a GitHub personal access token
@@ -46,7 +46,7 @@ In the root directory of your project, create another `.npmrc` file with the fol
 Then you can install a _developer package_ with the following command:
 
 ```sh
-npm install @codemonger-io/maplibre-collision-boxes@0.1.0-abc1234
+npm install @codemonger-io/maplibre-collision-boxes@0.1.1-abc1234
 ```
 
 Please replace `abc1234` with the short commit hash of the _snapshot_ you want to install.
@@ -78,7 +78,7 @@ You can find a complete project in the [`example`](./example) folder.
 
 ### Remarks on type compatibility
 
-While this library works with `maplibre-gl` version from 5.0.0 through version 5.6.2, you may face a type error at the call of the `collectCollisionBoxesAndFeatures` function if your `maplibre-gl` version is different from the one (5.6.2) for which this library is built.
+While this library works with `maplibre-gl` version from 5.0.0 through version 5.18.0, you may face a type error at the call of the `collectCollisionBoxesAndFeatures` function if your `maplibre-gl` version is different from the one (5.18.0) for which this library is built.
 Please ignore or suppress the type error in case you see it.
 
 ## Motivation

--- a/README_ja.md
+++ b/README_ja.md
@@ -78,7 +78,7 @@ const map.on('click', layerId, async event => {
 
 ### 型の互換性に関する留意点
 
-このライブラリは`mplibre-gl`のバージョン5.0.0から5.18.0で動作しますが、このライブラリをビルドした`maplibre-gl`のバージョン(5.18.0)と異なるバージョンを使っている場合は`collectCollisionBoxesAndFeatures`関数の呼び出し箇所で型エラーが発生する可能性があります。
+このライブラリは`maplibre-gl`のバージョン5.0.0から5.18.0で動作しますが、このライブラリをビルドした`maplibre-gl`のバージョン(5.18.0)と異なるバージョンを使っている場合は`collectCollisionBoxesAndFeatures`関数の呼び出し箇所で型エラーが発生する可能性があります。
 型エラーが出た場合は無視するか抑制してください。
 
 ## 動機

--- a/README_ja.md
+++ b/README_ja.md
@@ -9,20 +9,20 @@ Maplibreマップ上の衝突ボックスを画面座標系で計算する、[Ma
 ### 事前準備
 
 このライブラリは`maplibre-gl`バージョン5.xと一緒に使用する想定です。
-(開発はv5.6.2で行いました。)
+(テストはv5.18.0で行いました。)
 
 ### インストール方法
 
 このレポジトリを依存関係に追加してください。
 
 ```sh
-npm install https://github.com/codemonger-io/maplibre-collision-boxes#v0.1.0
+npm install https://github.com/codemonger-io/maplibre-collision-boxes#v0.1.1
 ```
 
 #### GitHub Packagesからインストールする
 
 `main`ブランチにコミットがプッシュされるたびに、*開発者用パッケージ*がGitHub Packagesが管理するnpmレジストリにパブリッシュされます。
-*開発者用パッケージ*のバージョンは次のリリースバージョンにハイフン(`-`)と短いコミットハッシュつなげたものになります。例、`0.1.0-abc1234` (`abc1234`はパッケージをビルドするのに使ったコミット(*スナップショット*)の短いコミットハッシュ)。
+*開発者用パッケージ*のバージョンは次のリリースバージョンにハイフン(`-`)と短いコミットハッシュつなげたものになります。例、`0.1.1-abc1234` (`abc1234`はパッケージをビルドするのに使ったコミット(*スナップショット*)の短いコミットハッシュ)。
 *開発者用パッケージ*は[こちら](https://github.com/codemonger-io/maplibre-collision-boxes/pkgs/npm/maplibre-collision-boxes)にあります。
 
 ##### GitHubパーソナルアクセストークンの設定
@@ -46,7 +46,7 @@ PATが手に入ったら以下の内容の`.npmrc`ファイルをホームディ
 これで以下のコマンドで*開発者用パッケージ*をインストールできます。
 
 ```sh
-npm install @codemonger-io/maplibre-collision-boxes@0.1.0-abc1234
+npm install @codemonger-io/maplibre-collision-boxes@0.1.1-abc1234
 ```
 
 `abc1234`はインストールしたい*スナップショット*の短いコミットハッシュに置き換えてください。
@@ -78,7 +78,7 @@ const map.on('click', layerId, async event => {
 
 ### 型の互換性に関する留意点
 
-このライブラリは`mplibre-gl`のバージョン5.0.0から5.6.2で動作しますが、このライブラリをビルドした`maplibre-gl`のバージョン(5.6.2)と異なるバージョンを使っている場合は`collectCollisionBoxesAndFeatures`関数の呼び出し箇所で型エラーが発生する可能性があります。
+このライブラリは`mplibre-gl`のバージョン5.0.0から5.18.0で動作しますが、このライブラリをビルドした`maplibre-gl`のバージョン(5.18.0)と異なるバージョンを使っている場合は`collectCollisionBoxesAndFeatures`関数の呼び出し箇所で型エラーが発生する可能性があります。
 型エラーが出た場合は無視するか抑制してください。
 
 ## 動機

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     maplibre-gl:
-      specifier: 5.10.0
-      version: 5.10.0
+      specifier: 5.18.0
+      version: 5.18.0
     npm-run-all2:
       specifier: ^8.0.4
       version: 8.0.4
@@ -34,7 +34,7 @@ importers:
         version: 3.4.4
       maplibre-gl:
         specifier: 'catalog:'
-        version: 5.10.0
+        version: 5.18.0
       npm-run-all2:
         specifier: 'catalog:'
         version: 8.0.4
@@ -58,7 +58,7 @@ importers:
         version: link:..
       maplibre-gl:
         specifier: 'catalog:'
-        version: 5.10.0
+        version: 5.18.0
       vue:
         specifier: ^3.5.28
         version: 3.5.28(typescript@5.8.3)
@@ -316,6 +316,9 @@ packages:
     resolution: {integrity: sha512-UKhA4qv1h30XT768ccSv5NjNCX+dgfoq2qlLVmKejspPcSQTYD4SrVucgqegmYcKcmwf06wcNAa/kRd0NHWbUg==}
     hasBin: true
 
+  '@maplibre/mlt@1.1.6':
+    resolution: {integrity: sha512-rgtY3x65lrrfXycLf6/T22ZnjTg5WgIOsptOIoCaMZy4O4UAKTyZlYY0h6v8le721pTptF94U65yMDQkug+URw==}
+
   '@maplibre/vt-pbf@4.2.1':
     resolution: {integrity: sha512-IxZBGq/+9cqf2qdWlFuQ+ZfoMhWpxDUGQZ/poPHOJBvwMUT1GuxLo6HgYTou+xxtsOsjfbcjI8PZaPCtmt97rA==}
 
@@ -525,9 +528,6 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/geojson-vt@3.2.5':
-    resolution: {integrity: sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==}
-
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
@@ -702,9 +702,6 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
-  geojson-vt@4.0.2:
-    resolution: {integrity: sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==}
-
   geojson@0.5.0:
     resolution: {integrity: sha512-/Bx5lEn+qRF4TfQ5aLu6NH+UKtvIv7Lhc487y/c8BdludrCTpiWf9wyI0RTyqg49MFefIAvFDuEi5Dfd/zgNxQ==}
     engines: {node: '>= 0.10'}
@@ -783,8 +780,8 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  maplibre-gl@5.10.0:
-    resolution: {integrity: sha512-eLhlX8Fnpaoo7+uGqggZmXmZld6WrbzOJUPB7G8JB8XpminlTnrQTtXilMHduR8fsNVxrzD8yRRqEoajONc8LQ==}
+  maplibre-gl@5.18.0:
+    resolution: {integrity: sha512-UtWxPBpHuFvEkM+5FVfcFG9ZKEWZQI6+PZkvLErr8Zs5ux+O7/KQ3JjSUvAfOlMeMgd/77qlHpOw0yHL7JU5cw==}
     engines: {node: '>=16.14.0', npm: '>=8.1.0'}
 
   memorystream@0.3.1:
@@ -1195,6 +1192,10 @@ snapshots:
       rw: 1.3.3
       tinyqueue: 3.0.0
 
+  '@maplibre/mlt@1.1.6':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+
   '@maplibre/vt-pbf@4.2.1':
     dependencies:
       '@mapbox/point-geometry': 1.1.0
@@ -1391,10 +1392,6 @@ snapshots:
   '@types/argparse@1.0.38': {}
 
   '@types/estree@1.0.8': {}
-
-  '@types/geojson-vt@3.2.5':
-    dependencies:
-      '@types/geojson': 7946.0.16
 
   '@types/geojson@7946.0.16': {}
 
@@ -1610,8 +1607,6 @@ snapshots:
 
   function-bind@1.1.2: {}
 
-  geojson-vt@4.0.2: {}
-
   geojson@0.5.0: {}
 
   get-stream@6.0.1: {}
@@ -1674,7 +1669,7 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  maplibre-gl@5.10.0:
+  maplibre-gl@5.18.0:
     dependencies:
       '@mapbox/geojson-rewind': 0.5.2
       '@mapbox/jsonlint-lines-primitives': 2.0.2
@@ -1683,13 +1678,13 @@ snapshots:
       '@mapbox/unitbezier': 0.0.1
       '@mapbox/vector-tile': 2.0.4
       '@mapbox/whoots-js': 3.1.0
+      '@maplibre/geojson-vt': 5.0.4
       '@maplibre/maplibre-gl-style-spec': 24.4.1
+      '@maplibre/mlt': 1.1.6
       '@maplibre/vt-pbf': 4.2.1
       '@types/geojson': 7946.0.16
-      '@types/geojson-vt': 3.2.5
       '@types/supercluster': 7.1.3
       earcut: 3.0.2
-      geojson-vt: 4.0.2
       gl-matrix: 3.4.4
       kdbush: 4.0.2
       murmurhash-js: 1.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,6 @@ packages:
   - example
 
 catalog:
-  maplibre-gl: 5.10.0
+  maplibre-gl: 5.18.0
   npm-run-all2: ^8.0.4
   typescript: 5.8.3

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,9 +81,13 @@ export async function collectCollisionBoxesAndFeatures(
   if (tileManager == null) {
     throw new Error(`no TileManager available`);
   }
-  const layerTiles = sourceCache.getRenderableIds(
-    true, // symbolLayer?
-  ).map(id => sourceCache.getTileByID(id));
+  const layerTiles = tileManager
+    .getRenderableIds(
+      true, // symbolLayer?
+    )
+    .map(id => tileManager.getTileByID(id))
+    // getTileByID may return undefined since v5.14.0
+    .filter(tile => tile != null);
   const transform = map.painter.transform;
   const collisionBoxesWithFeature = [];
   for (const tile of layerTiles) {

--- a/src/private/maplibre-types.ts
+++ b/src/private/maplibre-types.ts
@@ -28,7 +28,7 @@ export type Placement = Style['placement'];
 
 export type CollisionIndex = Placement['collisionIndex'];
 
-export type Tile = Style['sourceCaches']['string']['_tiles']['string'];
+export type Tile = Style['tileManagers']['string']['_inViewTiles']['_tiles']['string'];
 
 export type OverscaledTileID = Tile['tileID'];
 
@@ -41,7 +41,7 @@ export type Bucket = Tile['buckets']['string'];
 // Minimal interface of `SymbolBucket`.
 //
 // https://github.com/maplibre/maplibre-gl-js/blob/7887f2c899dcc7f7bfa8a05f5a98c92bf1a5bf5a/src/data/bucket/symbol_bucket.ts#L277-L955
-export type SymbolBucket = Bucket & {
+export interface SymbolBucket extends Bucket {
   // `globalState` was introduced in v5.6.0 but was removed in v5.7.2
   // https://github.com/maplibre/maplibre-gl-js/blob/b3e282bbb0b8f93b503895281ec313a4e2a1c6be/src/data/bucket/symbol_bucket.ts#L315
   globalState?: Record<string, any>;

--- a/src/private/maplibre-types.ts
+++ b/src/private/maplibre-types.ts
@@ -15,6 +15,12 @@ import type { Style } from 'maplibre-gl';
 // https://github.com/maplibre/maplibre-gl-js/blob/7887f2c899dcc7f7bfa8a05f5a98c92bf1a5bf5a/src/data/extent.ts#L13
 export const EXTENT = 8192;
 
+export interface StyleCompat extends Style {
+  // sourceCaches was replaced with tileManagers in v5.11.0.
+  // the signature is identical in terms of this library's usage.
+  sourceCaches?: Style['tileManagers'];
+};
+
 // NOTE: unpublished latest `maplibre-gl` exports `StyleLayer`.
 export type StyleLayer = Style['_layers'][number];
 


### PR DESCRIPTION
### Proposed changes

Fixes the issue that this library crashed with `maplibre-gl` v5.11.0 or higher. v5.11.0 replaced the `sourceCaches` field of `Style` with `tileManagers`. Works around the problem by using `tileManagers` while falling back to `sourceCaches`.

Also fixes type errors introduced since `maplibre-gl` v5.14.0.
- `TileManager` no longer has the `_tiles` field but has `_inViewTiles._tiles`. Derives the `Tile` type from `_inViewTiles._tiles` instead of `_tiles`.
- The type signature of `TileManager.getTileByID` changed. It may return `undefined` now.
- `isSymbolBucket` stopped working for an unknown reason. Fixes it by changing the declaration of `SymbolBucket` from `type` to `interface` extending `Bucket`.

### Related issue(s)

- closes #3